### PR TITLE
Fix extraneous execution in nonlinear solver module

### DIFF
--- a/solvers/nonlinear_solvers.py
+++ b/solvers/nonlinear_solvers.py
@@ -84,21 +84,21 @@ def newtonsmethod(G, JG, x_guess,  tol=1e-6, max_iter = 100):
 # funDer = lambda x: 2*x
 # x0 =0.1
 
-fun = lambda x: np.array([
-    x[0]**2 + x[1]**2 - 4,
-    x[0] - x[1]
-])
+if __name__ == "__main__":
+    fun = lambda x: np.array([
+        x[0]**2 + x[1]**2 - 4,
+        x[0] - x[1]
+    ])
 
-funDer = lambda x: np.array([
-    [2*x[0], 2*x[1]],
-    [1, -1]
-])
-x0 = np.array([0.1, 0.1])
+    funDer = lambda x: np.array([
+        [2*x[0], 2*x[1]],
+        [1, -1]
+    ])
 
+    x0 = np.array([0.1, 0.1])
 
-
-res = newtonsmethod(fun,funDer, x0)
-print(f"res is {res}")
+    res = newtonsmethod(fun, funDer, x0)
+    print(f"res is {res}")
 
 
  


### PR DESCRIPTION
## Summary
- prevent test code in `nonlinear_solvers.py` from running on import

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_688d4a438efc8332b5465cbf66ffefc6