### PR TITLE
Fix typo in AutomaticDifferentiation comment

### DIFF
--- a/differentiation_methods/AutomaticDifferentiation.py
+++ b/differentiation_methods/AutomaticDifferentiation.py
@@ -23,7 +23,7 @@ primitive_rules = {
 #vector jacobian product
 def vjp(chain, primal):
     
-    #primal pass, goes through each operation in the chain and saves the pullback accordigly
+    #primal pass, goes through each operation in the chain and saves the pullback accordingly
     #pullback chain
     pulllback_stack = []
     current_value = primal  #primal position where we want to evaluate tha chain 


### PR DESCRIPTION
## Summary
- fix a typo in `AutomaticDifferentiation.vjp` docstring comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d4d8e0cc0833284b03d99723971e3